### PR TITLE
Make ad image container block

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 			<form name="ad">
 				<ad-block>
 					<label for="ad-label" slot="label">Ad label / title</label>
-					<label for="ad-image" slot="image" class="inline-block">
+					<label for="ad-image" slot="image" class="block">
 						<svg class="current-color" viewBox="0 0 12 16">
 							<path fill-rule="evenodd" d="M6 5h2v2H6V5zm6-.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v11l3-5 2 4 2-2 3 3V5z"/>
 						</svg>


### PR DESCRIPTION
For whatever reason, in Chrome, `inline-block` means 0 sized.