### PR TITLE
Fix issue causing text overflow in toolbar buttons

### DIFF
--- a/css/nav.css
+++ b/css/nav.css
@@ -1,6 +1,7 @@
 #nav {
 	padding: 0.6em;
-	font-size: 1.2em;
+	font-size: 18px;
+	font-size: clamp(18px, 1.2em, 21px);
 	justify-content: space-around;
 	background-color: #DEDAD7;
 	gap: 0.6em;
@@ -10,7 +11,7 @@
 #nav .btn {
 	border: 1px solid #bfbfbf;
 	flex-grow: 1;
-	max-width: 200px;
+	max-width: 220px;
 }
 
 #nav .btn.btn-default {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global config */
 /* eslint-env serviceworker */
-/* 2020-10-26T09:14 */
+/* 2020-10-30T12:01 */
 
 self.importScripts('/sw-config.js');
 


### PR DESCRIPTION
Set font-size in px, with `clamp()` for when supported.