### PR TITLE
Fix installing Android app instead of PWA

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -100,7 +100,7 @@
       "application/krv-ad+json": [".krvad"]
     }
   }],
-  "prefer_related_applications": true,
+  "prefer_related_applications": false,
   "related_applications":  [{
     "platform": "play",
     "id": "us.kernvalley.ads.twa"


### PR DESCRIPTION
This was directing to Play Store instead of installing PWA due to `prefer_related_applications: true`.

Well, now I know what that does.